### PR TITLE
Add waiting on record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "prezi-cypress-image-snapshot",
+  "name": "@prezi/cypress-image-snapshot",
   "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezi/cypress-image-snapshot",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Cypress bindings for jest-image-snapshot.",
   "repository": "https://github.com/prezi/cypress-image-snapshot",
   "author": "Prezi Activation team <activationteam@prezi.com>",

--- a/src/command.js
+++ b/src/command.js
@@ -23,55 +23,80 @@ export function matchImageSnapshotCommand(defaultOptions) {
 
     const startTime = Date.now();
 
+    let cypressContext = Cypress.mocha.getRunner().suite.ctx.test;
+    let cypressPath = [cypressContext.title];
+    let rootCypressContext = cypressContext;
+    while (rootCypressContext.parent != null) {
+      rootCypressContext = rootCypressContext.parent;
+      cypressPath.push(rootCypressContext.title);
+    }
+
+    var name = typeof maybeName === 'string' ? maybeName : undefined;
+    const rawSnapshotFilepath = cypressContext.titlePath();
+    const snapshotFilepath = rawSnapshotFilepath.map(str =>
+      str.replace(/[/\\?%*:| "<>]/g, '-').toLowerCase()
+    );
+    if (name == undefined && snapshotFilepath.length > 0) {
+      name = snapshotFilepath.pop();
+    }
+    let forceWaiting = false;
+
     const match = () => {
       cy.task(MATCH, {
         screenshotsFolder,
         updateSnapshots,
+        snapshotFilepath,
+        snapshotName: name,
         options,
-      });
+      }).then(ret => {
+        forceWaiting = !ret.snapshotExists;
+        if (forceWaiting) {
+          // if we are
+          cy.wait(timeout);
+        }
 
-      const name = typeof maybeName === 'string' ? maybeName : undefined;
-      const target = subject ? cy.wrap(subject) : cy;
-      target.screenshot(name, options);
+        const target = subject ? cy.wrap(subject) : cy;
+        target.screenshot(name, options);
 
-      return cy
-        .task(RECORD)
-        .then(
-          ({
-            pass,
-            added,
-            updated,
-            diffSize,
-            imageDimensions,
-            diffRatio,
-            diffPixelCount,
-            diffOutputPath,
-          }) => {
-            if (!pass && !added && !updated) {
-              const message = diffSize
-                ? `Image size (${imageDimensions.baselineWidth}x${
-                    imageDimensions.baselineHeight
-                  }) different than saved snapshot size (${
-                    imageDimensions.receivedWidth
-                  }x${
-                    imageDimensions.receivedHeight
-                  }).\nSee diff for details: ${diffOutputPath}`
-                : `Image was ${diffRatio *
-                    100}% different from saved snapshot with ${diffPixelCount} different pixels.\nSee diff for details: ${diffOutputPath}`;
+        return cy
+          .task(RECORD)
+          .then(
+            ({
+              pass,
+              added,
+              updated,
+              diffSize,
+              imageDimensions,
+              diffRatio,
+              diffPixelCount,
+              diffOutputPath,
+            }) => {
+              if (!pass && !added && !updated) {
+                const message = diffSize
+                  ? `Image size (${imageDimensions.baselineWidth}x${
+                      imageDimensions.baselineHeight
+                    }) different than saved snapshot size (${
+                      imageDimensions.receivedWidth
+                    }x${
+                      imageDimensions.receivedHeight
+                    }).\nSee diff for details: ${diffOutputPath}`
+                  : `Image was ${diffRatio *
+                      100}% different from saved snapshot with ${diffPixelCount} different pixels.\nSee diff for details: ${diffOutputPath}`;
 
-              if (failOnSnapshotDiff) {
-                const currentTime = Date.now();
-                if (currentTime - startTime < timeout) {
-                  match();
+                if (failOnSnapshotDiff) {
+                  const currentTime = Date.now();
+                  if (currentTime - startTime < timeout && !forceWaiting) {
+                    match();
+                  } else {
+                    throw new Error(message);
+                  }
                 } else {
-                  throw new Error(message);
+                  Cypress.log(message);
                 }
-              } else {
-                Cypress.log(message);
               }
             }
-          }
-        );
+          );
+      });
     };
     match();
   };

--- a/src/command.js
+++ b/src/command.js
@@ -37,6 +37,7 @@ export function matchImageSnapshotCommand(defaultOptions) {
       str.replace(/[/\\?%*:| "<>]/g, '-').toLowerCase()
     );
     if (name == undefined && snapshotFilepath.length > 0) {
+      // if the snapshot name is not specified use the name of the test case
       name = snapshotFilepath.pop();
     }
     let forceWaiting = false;
@@ -51,7 +52,8 @@ export function matchImageSnapshotCommand(defaultOptions) {
       }).then(ret => {
         forceWaiting = !ret.snapshotExists;
         if (forceWaiting) {
-          // if we are
+          // if we are recording a test case for the first time we
+          // need to wait for the result to be correct instead of retrying
           cy.wait(timeout);
         }
 
@@ -86,6 +88,7 @@ export function matchImageSnapshotCommand(defaultOptions) {
                 if (failOnSnapshotDiff) {
                   const currentTime = Date.now();
                   if (currentTime - startTime < timeout && !forceWaiting) {
+                    // retry matching the image
                     match();
                   } else {
                     throw new Error(message);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -90,11 +90,6 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   const receivedImageBuffer = fs.readFileSync(screenshotPath);
   fs.removeSync(screenshotPath);
 
-  const { dir: screenshotDir, name: snapshotIdentifier } = path.parse(
-    screenshotPath
-  );
-
-  const relativePath = path.relative(screenshotsFolder, screenshotDir);
   const snapshotsDir = customSnapshotsDir
     ? path.join(process.cwd(), customSnapshotsDir, ...snapshotFilepath)
     : path.join(screenshotsFolder, '..', 'snapshots', ...snapshotFilepath);


### PR DESCRIPTION
Changes how the snapshot pathes are calculated. Now there will be recursive folders for the test cases.
Checks for the reference images before taking the snapshot and if the image does not exist waits for the full timeout and only then takes the picture (avoid taking a bad picture too early). Otherwise takes the picture immediately and retries until the timeout is gone.