### PR TITLE
[AC-2849] Remove diff images after success

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezi/cypress-image-snapshot",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Cypress bindings for jest-image-snapshot.",
   "repository": "https://github.com/prezi/cypress-image-snapshot",
   "author": "Prezi Activation team <activationteam@prezi.com>",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -121,8 +121,8 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   });
 
   const { pass, added, updated, diffOutputPath } = snapshotResult;
-
-  if (!pass && !added && !updated) {
+  const isFailed = !pass && !added && !updated;
+  if (isFailed) {
     fs.copySync(diffOutputPath, diffDotPath);
     fs.removeSync(diffOutputPath);
     fs.removeSync(snapshotKebabPath);
@@ -134,6 +134,12 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   } else {
     if (!pass) {
       fs.copySync(snapshotKebabPath, snapshotDotPath);
+    }
+    const isPassedAfterFailure =
+      pass && !added && !updated && fs.existsSync(diffDotPath);
+    if (isPassedAfterFailure) {
+      console.log(`Removing file after success: ${diffDotPath}`);
+      fs.removeSync(diffDotPath);
     }
     fs.removeSync(snapshotKebabPath);
     snapshotResult.diffOutputPath = snapshotDotPath;


### PR DESCRIPTION
Cypress is making the screenshot diffs until either the set timeout is reached or a successful diff happens. From now on, the diffs will be cleaned up after success.